### PR TITLE
Add performance flags for better training and inference performance on Intel hardware

### DIFF
--- a/nets/ssd.py
+++ b/nets/ssd.py
@@ -215,7 +215,7 @@ class SSDModel():
             with slim.arg_scope([slim.conv2d],
                             activation_fn=None, data_format=data_format):
                 with slim.arg_scope([slim.batch_norm],
-                            activation_fn=tf.nn.relu, is_training=is_training,updates_collections=None，
+                            activation_fn=tf.nn.relu, is_training=is_training,updates_collections=None,
                             data_format=data_format):
                     with slim.arg_scope([slim.dropout],
                             is_training=is_training,keep_prob=keep_prob):

--- a/nets/ssd.py
+++ b/nets/ssd.py
@@ -181,9 +181,9 @@ class SSDModel():
                     return sc
 
     
-    def get_model(self,inputs, weight_decay=0.0005,is_training=False):
+    def get_model(self,inputs, weight_decay=0.0005,is_training=False,data_format='NHWC'):
         # End_points collect relevant activations for external use.
-        arg_scope = self.__arg_scope(weight_decay=weight_decay)
+        arg_scope = self.__arg_scope(weight_decay=weight_decay,data_format=data_format)
         with slim.arg_scope(arg_scope):
             end_points = {}
             with tf.variable_scope('vgg_16', [inputs]):
@@ -213,9 +213,10 @@ class SSDModel():
             # Additional SSD blocks.
             keep_prob=0.8
             with slim.arg_scope([slim.conv2d],
-                            activation_fn=None):
+                            activation_fn=None, data_format=data_format):
                 with slim.arg_scope([slim.batch_norm],
-                            activation_fn=tf.nn.relu, is_training=is_training,updates_collections=None):
+                            activation_fn=tf.nn.relu, is_training=is_training,updates_collections=None，
+                            data_format=data_format):
                     with slim.arg_scope([slim.dropout],
                             is_training=is_training,keep_prob=keep_prob):
                         with tf.variable_scope(self.model_name):

--- a/preparedata.py
+++ b/preparedata.py
@@ -18,13 +18,13 @@ import math
 
 class PrepareData():
     def __init__(self):
-        
+
         self.batch_size = 32
         self.labels_offset = 0
-        
-        
+
+
         self.matched_thresholds = 0.5 #threshold for anchor matching strategy
-      
+        self.data_format = 'NCHW'
         
        
         
@@ -33,9 +33,9 @@ class PrepareData():
     def __preprocess_data(self, image, labels, bboxes):
         out_shape = g_ssd_model.img_shape
         if self.is_training_data:
-            image, labels, bboxes = preprocess_for_train(image, labels, bboxes, out_shape = out_shape)
+            image, labels, bboxes = preprocess_for_train(image, labels, bboxes, out_shape = out_shape, data_format= self.data_format)
         else:
-            image, labels, bboxes, _ = preprocess_for_eval(image, labels, bboxes, out_shape = out_shape)
+            image, labels, bboxes, _ = preprocess_for_eval(image, labels, bboxes, out_shape = out_shape, data_format= self.data_format)
         return image, labels, bboxes
     def __get_images_labels_bboxes(self,data_sources, num_samples,is_training_data):
         

--- a/tf_utils.py
+++ b/tf_utils.py
@@ -14,9 +14,9 @@
 # ==============================================================================
 """Diverse TensorFlow utils, for training, evaluation and so on!
 """
+from __future__ import print_function
 import os
 from pprint import pprint
-from __future__ import print_function
 import tensorflow as tf
 from tensorflow.contrib.slim.python.slim.data import parallel_reader
 

--- a/tf_utils.py
+++ b/tf_utils.py
@@ -16,7 +16,7 @@
 """
 import os
 from pprint import pprint
-
+from __future__ import print_function
 import tensorflow as tf
 from tensorflow.contrib.slim.python.slim.data import parallel_reader
 

--- a/train_model.py
+++ b/train_model.py
@@ -425,7 +425,7 @@ class TrainModel(PrepareData):
         
         
         self.max_number_of_steps = 30000
-        self.log_every_n_steps = 10
+        self.log_every_n_steps = 100
         
         self.learning_rate = 0.1
         self.learning_rate_decay_type = 'fixed'

--- a/train_model.py
+++ b/train_model.py
@@ -425,7 +425,7 @@ class TrainModel(PrepareData):
         
         
         self.max_number_of_steps = 30000
-        self.log_every_n_steps = 100
+        self.log_every_n_steps = 10
         
         self.learning_rate = 0.1
         self.learning_rate_decay_type = 'fixed'


### PR DESCRIPTION
I'm a part of the TensorFlow optimization team at Intel and we're working on improving performance of SSD-VGG16 on Intel Hardware. As a first step, I'm adding the ability to tweak performance and switch data format. We will also contribute changes to TensorFlow and MKL-DNN to speed up SSD-VGG16.

Added flags for getting better performance during training/inference when running on TensorFlow built with MKL-DNN. With the right settings (Inter_op 2, intra_op 2 and mkl True), training/inference performance on a 28 core Xeon Scalable Processor get much better, we also verified the mAP values matches GPU mAP (65% after 120k steps).

For more info about TF with Intel MKL-DNN, please check website: https://www.tensorflow.org/performance/performance_guide#tensorflow_with_intel%C2%AE_mkl_dnn